### PR TITLE
Adds code to check for existing nodes and skip unless flag is set

### DIFF
--- a/provision-solr.yml
+++ b/provision-solr.yml
@@ -38,6 +38,14 @@
       - set_fact:
           num_solr_nodes: "{{groups['solr'] | default([]) | length}}"
           num_zk_nodes: "{{groups['zookeeper'] | default([]) | length}}"
+      # if an existing set of Solr/Fusion nodes were found, throw an error
+      # unless the reuse_existing_nodes flag was set to 'true' or 'yes')
+      - block:
+        - name: Fail playbook run if existing nodes found and user did not request reuse
+          fail:
+            msg: "Found an existing set of nodes - {{(groups['solr'] | to_yaml).split('\n').0}}; aborting playbook run"
+          when: not((reuse_existing_nodes | default(false)) | bool)
+        when: num_solr_nodes | int > 0
       # if an external Zookeeper ensemble (or node) was not found and we're
       # deploying an Solr/Fusion cluster (or multiple matching Solr/Fusion
       # nodes were found), then it's an error


### PR DESCRIPTION
The changes in this pull request modify the existing `provision-solr.yml` playbook so that:

* if a set of existing Solr/Fusion nodes (one or more) are found during the playbook run that match the tags that were passed into the playbook, then an error is thrown unless the newly added `reuse_existing_nodes` flag is set (to either `true` or `yes`)
* if that flag is set and an existing set of Solr/Fusion nodes are found during the playbook run, then those nodes will be used for the planned Solr/Fusion deployment

This new `reuse_existing_nodes` flag defaults to `false` if it is not defined during the playbook run, so by default the `provision-solr.yml` playbook will fail with a simple error rather than reusing the existing (matching) nodes for the Solr/Fusion deployment. This prevents users from accidentally targeting an existing cluster/ensemble by passing the wrong tags into the playbook run.

This flag becomes useful in the scenario where the playbook as created a new set of target nodes in a target cloud environment but the playbook then failed part way through the remaining plays in the playbook. In that scenario, this flag can be set by the user to target the (partially configured) set of existing nodes in the rest of the playbook run (rather than forcing the user to start over by redeploying the existing nodes).