### PR TITLE
Add labels to the fail tasks to clarify output of playbook runs

### DIFF
--- a/provision-solr.yml
+++ b/provision-solr.yml
@@ -22,10 +22,12 @@
           node_map_entries: "{{node_map | selectattr('application', 'equalto', application) | list}}"
       # if more than one node_map entry was found or no matching node_map
       # entries were found, then it's an error
-      - fail:
+      - name: Fail playbook run if multiple solr node_map entries were found
+        fail:
           msg: "Multiple {{application}} node_map entries found"
         when: node_map_entries | length > 1
-      - fail:
+      - name: Fail playbook run if no solr node_map entries were found
+        fail:
           msg: "No {{application}} node_map entries found"
         when: node_map_entries | length == 0
       # build the solr and zookeeper host groups from existing inventory
@@ -49,7 +51,8 @@
       # if an external Zookeeper ensemble (or node) was not found and we're
       # deploying an Solr/Fusion cluster (or multiple matching Solr/Fusion
       # nodes were found), then it's an error
-      - fail:
+      - name: Fail playbook run if cluster deployment and external zookeeper ensemble not found
+        fail:
           msg: "An external Zookeeper ensemble is required for Solr/Fusion cluster deployments"
         when:
           - (num_solr_nodes | int == 0 and node_map_entries.0.count > 1) or num_solr_nodes | int > 1
@@ -58,10 +61,12 @@
       # instances into the target cloud environment, ensuring that there
       # are an appropriately tagged, based on the input tags and the node_map
       # entries for this application
-      - include_role:
+      - name: Launch AWS VMs
+        include_role:
           name: 'aws'
         when: num_solr_nodes | int == 0 and cloud == 'aws'
-      - include_role:
+      - name: Launch OSP VMs
+        include_role:
           name: 'osp'
         when: num_solr_nodes | int == 0 and cloud == 'osp'
       when: cloud is defined and (cloud == 'aws' or cloud == 'osp')

--- a/roles/osp/tasks/launch-vms.yml
+++ b/roles/osp/tasks/launch-vms.yml
@@ -260,7 +260,7 @@
 
 # wait_for doesn't work with a proxy, so we need to ssh and check output
 - name: Wait for instances to be accessible via SSH
-  shell: /bin/sleep 20 && /usr/bin/ssh -i "{{ private_keyfile_path }}" "{{ user }}@{{ hostvars[item.server.addresses.private.0['addr']].ansible_host }}" echo DataNexus  
+  shell: /bin/sleep 20 && /usr/bin/ssh -i "{{ private_keyfile_path }}" "{{ user }}@{{ hostvars[item.server.addresses.private.0['addr']].ansible_host }}" echo DataNexus
   register: output
   retries: 4
   delay: 10

--- a/roles/preflight/tasks/main.yml
+++ b/roles/preflight/tasks/main.yml
@@ -11,7 +11,7 @@
       dest: "/etc/sysconfig/network-scripts/ifcfg-{{api_iface}}"
       remote_src: True
   - name: Replace the device in the new ifcfg-{{api_iface}} script
-    lineinfile: 
+    lineinfile:
       name: "/etc/sysconfig/network-scripts/ifcfg-{{api_iface}}"
       regexp: '^DEVICE='
       line: 'DEVICE="{{api_iface}}"'
@@ -81,7 +81,7 @@
   - name: Set hostname actively so rebooting is unnecessary
     command: /usr/bin/hostnamectl set-hostname {{application}}-{{uuid.stdout}}
   - name: Set pretty hostname actively so rebooting is unnecessary
-    command: /usr/bin/hostnamectl --pretty set-hostname "{{tenant}} {{application}}"  
+    command: /usr/bin/hostnamectl --pretty set-hostname "{{tenant}} {{application}}"
   - name: Set new hostname in /etc/hostname
     replace:
       path: /etc/hostname


### PR DESCRIPTION
The changes in this pull request add labels to the fail tasks in the `provision-solr.yml` playbook (to clarify the output of the playbook run; some users were confused by the `fail ... skipped` output generated by previous versions of this playbook). In addition, this pull request makes the following changes:

* It ensures that the labels added to the `include_role` tasks that include the `aws` and `osp` roles are consistent with these same labels in our other application playbooks (to make the output from our various playbooks more consistent; this change was made to some playbooks but not to others and the labels added were not consistent across the playbooks where they were added)
* It removes a bit of extraneous whitespace in a few of the files in the `roles` subdirectory (whitespace at the end of lines in a file can be a pain to deal with sometimes, can't it?)

With these changes, the `solr` repository should now be in line with recent changes that have been made to our other application repositories (`kafka`, `cassandra`, etc.)