### PR TITLE
Rolling back version to previous minor release

### DIFF
--- a/vars/solr.yml
+++ b/vars/solr.yml
@@ -8,7 +8,7 @@ application: solr
 # the Fusion version that should be installed and the URL that should be used
 # to download the Fusion (Solr) distribution (the Fusion package is distributed
 # as a gzipped tarfile)
-solr_version: 3.1.2
+solr_version: 3.1.1
 solr_url: "https://download.lucidworks.com/fusion-{{solr_version}}/fusion-{{solr_version}}.tar.gz"
 
 # the directory where the solr data will be written


### PR DESCRIPTION
We recently ran into issues with deployments based on the latest (v3.1.2) release of Fusion. This PR rolls the default version deployed by the playbook in this repository back to the previous minor release (v3.1.1) which is known to work. Once we've sorted out the issues with deploying v3.1.2 we can submit another PR to increment the playbook to deploying the latest version.