### PR TITLE
Fixes #6 (the default 'private_key_path' value is not set consistently)

### DIFF
--- a/vars/solr.yml
+++ b/vars/solr.yml
@@ -31,7 +31,7 @@ solr_package_list: ["java-1.8.0-openjdk", "java-1.8.0-openjdk-devel"]
 local_solr_file: ""
 
 # path used to access private keys (defaults to the current working directory)
-private_key_path: "."
+private_key_path: "{{playbook_dir}}"
 
 # fusion.properties values
 default_gc_type: g1


### PR DESCRIPTION
This PR changes the default value for the `private_key_path` defined [here](https://github.com/Datanexus/solr/blob/master/vars/solr.yml#L34) from the current working directory to the `playbook_dir` (a value that is set to the playbook directory). This brings this repository into line with the rest of our application playbook repositories (which use the `playbook_dir` as the default value for this parameter).